### PR TITLE
revert original contracts

### DIFF
--- a/contracts/BinaryOption.sol
+++ b/contracts/BinaryOption.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.5.16;
 
 // Inheritance
-import "synthetix-2.43.1/contracts/interfaces/IERC20.sol";
+import "./interfaces/IERC20.sol";
 import "./interfaces/IBinaryOption.sol";
 
 // Libraries
-import "synthetix-2.43.1/contracts/SafeDecimalMath.sol";
+import "./SafeDecimalMath.sol";
 
 // Internal references
 import "./BinaryOptionMarket.sol";
@@ -19,11 +19,14 @@ contract BinaryOption is IERC20, IBinaryOption {
 
     /* ========== STATE VARIABLES ========== */
 
-    string public name;
-    string public symbol;
+    string public constant name = "SNX Binary Option";
+    string public constant symbol = "sOPT";
     uint8 public constant decimals = 18;
 
     BinaryOptionMarket public market;
+
+    mapping(address => uint) public bidOf;
+    uint public totalBids;
 
     mapping(address => uint) public balanceOf;
     uint public totalSupply;
@@ -31,38 +34,110 @@ contract BinaryOption is IERC20, IBinaryOption {
     // The argument order is allowance[owner][spender]
     mapping(address => mapping(address => uint)) public allowance;
 
-    // Enforce a 1 cent minimum amount
-    uint internal constant _MINIMUM_AMOUNT = 1e16;
+    // Enforce a 1 cent minimum bid balance
+    uint internal constant _MINIMUM_BID = 1e16;
 
     /* ========== CONSTRUCTOR ========== */
 
-    bool public initialized = false;
-
-    function initialize(
-        string memory _name,
-        string memory _symbol
-    ) public {
-        require(!initialized, "Binary Option Market already initialized");
-        initialized = true;
-        name = _name;
-        symbol = _symbol;
+    constructor(address initialBidder, uint initialBid) public {
         market = BinaryOptionMarket(msg.sender);
+        bidOf[initialBidder] = initialBid;
+        totalBids = initialBid;
+    }
+
+    /* ========== VIEWS ========== */
+
+    function _claimableBalanceOf(
+        uint _bid,
+        uint price,
+        uint exercisableDeposits
+    ) internal view returns (uint) {
+        uint owed = _bid.divideDecimal(price);
+        uint supply = _totalClaimableSupply(exercisableDeposits);
+
+        /* The last claimant might be owed slightly more or less than the actual remaining deposit
+           based on rounding errors with the price.
+           Therefore if the user's bid is the entire rest of the pot, just give them everything that's left.
+           If there is no supply, then this option lost, and we'll return 0.
+           */
+        if ((_bid == totalBids && _bid != 0) || supply == 0) {
+            return supply;
+        }
+
+        /* Note that option supply on the losing side and deposits can become decoupled,
+           but losing options are not claimable, therefore we only need to worry about
+           the situation where supply < owed on the winning side.
+
+           If somehow a user who is not the last bidder is owed more than what's available,
+           subsequent bidders will be disadvantaged. Given that the minimum bid is 10^16 wei,
+           this should never occur in reality. */
+        require(owed <= supply, "supply < claimable");
+        return owed;
+    }
+
+    function claimableBalanceOf(address account) external view returns (uint) {
+        (uint price, uint exercisableDeposits) = market.senderPriceAndExercisableDeposits();
+        return _claimableBalanceOf(bidOf[account], price, exercisableDeposits);
+    }
+
+    function _totalClaimableSupply(uint exercisableDeposits) internal view returns (uint) {
+        uint _totalSupply = totalSupply;
+        // We'll avoid throwing an exception here to avoid breaking any dapps, but this case
+        // should never occur given the minimum bid size.
+        if (exercisableDeposits <= _totalSupply) {
+            return 0;
+        }
+        return exercisableDeposits.sub(_totalSupply);
+    }
+
+    function totalClaimableSupply() external view returns (uint) {
+        (, uint exercisableDeposits) = market.senderPriceAndExercisableDeposits();
+        return _totalClaimableSupply(exercisableDeposits);
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */
 
-    function _requireMinimumAmount(uint amount) internal pure returns (uint) {
-        require(amount >= _MINIMUM_AMOUNT || amount == 0, "Balance < $0.01");
-        return amount;
+    function _requireMinimumBid(uint bid) internal pure returns (uint) {
+        require(bid >= _MINIMUM_BID || bid == 0, "Balance < $0.01");
+        return bid;
     }
 
-    function mint(address minter, uint amount) external onlyMarket {
-        _requireMinimumAmount(amount);
-        totalSupply = totalSupply.add(amount);
-        balanceOf[minter] = balanceOf[minter].add(amount); // Increment rather than assigning since a transfer may have occurred.
+    // This must only be invoked during bidding.
+    function bid(address bidder, uint newBid) external onlyMarket {
+        bidOf[bidder] = _requireMinimumBid(bidOf[bidder].add(newBid));
+        totalBids = totalBids.add(newBid);
+    }
 
-        emit Transfer(address(0), minter, amount);
-        emit Issued(minter, amount);
+    // This must only be invoked during bidding.
+    function refund(address bidder, uint newRefund) external onlyMarket {
+        // The safe subtraction will catch refunds that are too large.
+        bidOf[bidder] = _requireMinimumBid(bidOf[bidder].sub(newRefund));
+        totalBids = totalBids.sub(newRefund);
+    }
+
+    // This must only be invoked after bidding.
+    function claim(
+        address claimant,
+        uint price,
+        uint depositsRemaining
+    ) external onlyMarket returns (uint optionsClaimed) {
+        uint _bid = bidOf[claimant];
+        uint claimable = _claimableBalanceOf(_bid, price, depositsRemaining);
+        // No options to claim? Nothing happens.
+        if (claimable == 0) {
+            return 0;
+        }
+
+        totalBids = totalBids.sub(_bid);
+        bidOf[claimant] = 0;
+
+        totalSupply = totalSupply.add(claimable);
+        balanceOf[claimant] = balanceOf[claimant].add(claimable); // Increment rather than assigning since a transfer may have occurred.
+
+        emit Transfer(address(0), claimant, claimable);
+        emit Issued(claimant, claimable);
+
+        return claimable;
     }
 
     // This must only be invoked after maturity.
@@ -88,12 +163,15 @@ contract BinaryOption is IERC20, IBinaryOption {
 
     /* ---------- ERC20 Functions ---------- */
 
+    // This should only operate after bidding;
+    // Since options can't be claimed until after bidding, all balances are zero until that time.
+    // So we don't need to explicitly check the timestamp to prevent transfers.
     function _transfer(
         address _from,
         address _to,
         uint _value
     ) internal returns (bool success) {
-        market.requireUnpaused();
+        market.requireActiveAndUnpaused();
         require(_to != address(0) && _to != address(this), "Invalid address");
 
         uint fromBalance = balanceOf[_from];

--- a/contracts/BinaryOption.sol
+++ b/contracts/BinaryOption.sol
@@ -10,7 +10,6 @@ import "./SafeDecimalMath.sol";
 // Internal references
 import "./BinaryOptionMarket.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/binaryoption
 contract BinaryOption is IERC20, IBinaryOption {
     /* ========== LIBRARIES ========== */
 

--- a/contracts/BinaryOptionMarket.sol
+++ b/contracts/BinaryOptionMarket.sol
@@ -1,21 +1,22 @@
 pragma solidity ^0.5.16;
 
 // Inheritance
-import "synthetix-2.43.1/contracts/MinimalProxyFactory.sol";
-import "./OwnedWithInit.sol";
+import "./Owned.sol";
+import "./MixinResolver.sol";
 import "./interfaces/IBinaryOptionMarket.sol";
 
 // Libraries
-import "synthetix-2.43.1/contracts/SafeDecimalMath.sol";
+import "./SafeDecimalMath.sol";
 
 // Internal references
 import "./BinaryOptionMarketManager.sol";
 import "./BinaryOption.sol";
-import "synthetix-2.43.1/contracts/interfaces/IExchangeRates.sol";
-import "synthetix-2.43.1/contracts/interfaces/IERC20.sol";
-import "synthetix-2.43.1/contracts/interfaces/IAddressResolver.sol";
+import "./interfaces/IExchangeRates.sol";
+import "./interfaces/IERC20.sol";
+import "./interfaces/IFeePool.sol";
 
-contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOptionMarket {
+// https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarket
+contract BinaryOptionMarket is Owned, MixinResolver, IBinaryOptionMarket {
     /* ========== LIBRARIES ========== */
 
     using SafeMath for uint;
@@ -28,7 +29,13 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
         BinaryOption short;
     }
 
+    struct Prices {
+        uint long;
+        uint short;
+    }
+
     struct Times {
+        uint biddingEnd;
         uint maturity;
         uint expiry;
     }
@@ -42,77 +49,99 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
     /* ========== STATE VARIABLES ========== */
 
     Options public options;
+    Prices public prices;
     Times public times;
     OracleDetails public oracleDetails;
     BinaryOptionMarketManager.Fees public fees;
-    IAddressResolver public resolver;
+    BinaryOptionMarketManager.CreatorLimits public creatorLimits;
 
-    // `deposited` tracks the sum of all deposits minus the withheld fees.
+    // `deposited` tracks the sum of open bids on short and long, plus withheld refund fees.
     // This must explicitly be kept, in case tokens are transferred to the contract directly.
     uint public deposited;
-    uint public initialMint;
     address public creator;
     bool public resolved;
+    bool public refundsEnabled;
 
     uint internal _feeMultiplier;
 
     /* ---------- Address Resolver Configuration ---------- */
 
+    bytes32 internal constant CONTRACT_SYSTEMSTATUS = "SystemStatus";
     bytes32 internal constant CONTRACT_EXRATES = "ExchangeRates";
     bytes32 internal constant CONTRACT_SYNTHSUSD = "SynthsUSD";
+    bytes32 internal constant CONTRACT_FEEPOOL = "FeePool";
 
     /* ========== CONSTRUCTOR ========== */
 
-    bool public initialized = false;
-
-    function initialize(
+    constructor(
         address _owner,
-        address _binaryOptionMastercopy,
-        IAddressResolver _resolver,
         address _creator,
+        address _resolver,
+        uint[2] memory _creatorLimits, // [capitalRequirement, skewLimit]
         bytes32 _oracleKey,
         uint _strikePrice,
-        uint[2] memory _times, // [maturity, expiry]
-        uint _deposit, // sUSD deposit
-        uint[2] memory _fees // [poolFee, creatorFee]
-    ) public {
-        require(!initialized, "Binary Option Market already initialized");
-        initialized = true;
-        initOwner(_owner);
-        resolver = _resolver;
+        bool _refundsEnabled,
+        uint[3] memory _times, // [biddingEnd, maturity, expiry]
+        uint[2] memory _bids, // [longBid, shortBid]
+        uint[3] memory _fees // [poolFee, creatorFee, refundFee]
+    ) public Owned(_owner) MixinResolver(_resolver) {
         creator = _creator;
+        creatorLimits = BinaryOptionMarketManager.CreatorLimits(_creatorLimits[0], _creatorLimits[1]);
 
         oracleDetails = OracleDetails(_oracleKey, _strikePrice, 0);
-        times = Times(_times[0], _times[1]);
+        times = Times(_times[0], _times[1], _times[2]);
 
-        deposited = _deposit;
-        initialMint = _deposit;
+        refundsEnabled = _refundsEnabled;
+
+        (uint longBid, uint shortBid) = (_bids[0], _bids[1]);
+        _checkCreatorLimits(longBid, shortBid);
+        emit Bid(Side.Long, _creator, longBid);
+        emit Bid(Side.Short, _creator, shortBid);
+
+        // Note that the initial deposit of synths must be made by the manager, otherwise the contract's assumed
+        // deposits will fall out of sync with its actual balance. Similarly the total system deposits must be updated in the manager.
+        // A balance check isn't performed here since the manager doesn't know the address of the new contract until after it is created.
+        uint initialDeposit = longBid.add(shortBid);
+        deposited = initialDeposit;
 
         (uint poolFee, uint creatorFee) = (_fees[0], _fees[1]);
-        fees = BinaryOptionMarketManager.Fees(poolFee, creatorFee);
+        fees = BinaryOptionMarketManager.Fees(poolFee, creatorFee, _fees[2]);
         _feeMultiplier = SafeDecimalMath.unit().sub(poolFee.add(creatorFee));
 
-        // Instantiate the options themselves
-        options.long = BinaryOption(_cloneAsMinimalProxy(_binaryOptionMastercopy, "Could not create a Binary Option"));
-        options.short = BinaryOption(_cloneAsMinimalProxy(_binaryOptionMastercopy, "Could not create a Binary Option"));
-        // abi.encodePacked("sLONG: ", _oracleKey)
-        // consider naming the option: sLongBTC>50@2021.12.31
-        options.long.initialize("Binary Option Long", "sLONG");
-        options.short.initialize("Binary Option Short", "sSHORT");
-        _mint(creator, initialMint);
+        // Compute the prices now that the fees and deposits have been set.
+        _updatePrices(longBid, shortBid, initialDeposit);
 
-        // Note: the ERC20 base contract does not have a constructor, so we do not have to worry
-        // about initializing its state separately
+        // Instantiate the options themselves
+        options.long = new BinaryOption(_creator, longBid);
+        options.short = new BinaryOption(_creator, shortBid);
+    }
+
+    /* ========== VIEWS ========== */
+
+    function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
+        addresses = new bytes32[](4);
+        addresses[0] = CONTRACT_SYSTEMSTATUS;
+        addresses[1] = CONTRACT_EXRATES;
+        addresses[2] = CONTRACT_SYNTHSUSD;
+        addresses[3] = CONTRACT_FEEPOOL;
     }
 
     /* ---------- External Contracts ---------- */
 
+    function _systemStatus() internal view returns (ISystemStatus) {
+        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
+    }
+
     function _exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(resolver.requireAndGetAddress(CONTRACT_EXRATES, "ExchangeRates contract not found"));
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));
     }
 
     function _sUSD() internal view returns (IERC20) {
-        return IERC20(resolver.requireAndGetAddress(CONTRACT_SYNTHSUSD, "SynthsUSD contract not found"));
+        return IERC20(requireAndGetAddress(CONTRACT_SYNTHSUSD));
+    }
+
+    function _feePool() internal view returns (IFeePool) {
+        return IFeePool(requireAndGetAddress(CONTRACT_FEEPOOL));
     }
 
     function _manager() internal view returns (BinaryOptionMarketManager) {
@@ -120,6 +149,10 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
     }
 
     /* ---------- Phases ---------- */
+
+    function _biddingEnded() internal view returns (bool) {
+        return times.biddingEnd < now;
+    }
 
     function _matured() internal view returns (bool) {
         return times.maturity < now;
@@ -130,6 +163,9 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
     }
 
     function phase() external view returns (Phase) {
+        if (!_biddingEnded()) {
+            return Phase.Bidding;
+        }
         if (!_matured()) {
             return Phase.Trading;
         }
@@ -174,7 +210,127 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
         return _result();
     }
 
-    /* ---------- Option Balances and Mints ---------- */
+    /* ---------- Option Prices ---------- */
+
+    function _computePrices(
+        uint longBids,
+        uint shortBids,
+        uint _deposited
+    ) internal view returns (uint long, uint short) {
+        require(longBids != 0 && shortBids != 0, "Bids must be nonzero");
+        uint optionsPerSide = _exercisableDeposits(_deposited);
+
+        // The math library rounds up on an exact half-increment -- the price on one side may be an increment too high,
+        // but this only implies a tiny extra quantity will go to fees.
+        return (longBids.divideDecimalRound(optionsPerSide), shortBids.divideDecimalRound(optionsPerSide));
+    }
+
+    function senderPriceAndExercisableDeposits() external view returns (uint price, uint exercisable) {
+        // When the market is not yet resolved, both sides might be able to exercise all the options.
+        // On the other hand, if the market has resolved, then only the winning side may exercise.
+        exercisable = 0;
+        if (!resolved || address(_option(_result())) == msg.sender) {
+            exercisable = _exercisableDeposits(deposited);
+        }
+
+        // Send the correct price for each side of the market.
+        if (msg.sender == address(options.long)) {
+            price = prices.long;
+        } else if (msg.sender == address(options.short)) {
+            price = prices.short;
+        } else {
+            revert("Sender is not an option");
+        }
+    }
+
+    function pricesAfterBidOrRefund(
+        Side side,
+        uint value,
+        bool refund
+    ) external view returns (uint long, uint short) {
+        (uint longTotalBids, uint shortTotalBids) = _totalBids();
+        // prettier-ignore
+        function(uint, uint) pure returns (uint) operation = refund ? SafeMath.sub : SafeMath.add;
+
+        if (side == Side.Long) {
+            longTotalBids = operation(longTotalBids, value);
+        } else {
+            shortTotalBids = operation(shortTotalBids, value);
+        }
+
+        if (refund) {
+            value = value.multiplyDecimalRound(SafeDecimalMath.unit().sub(fees.refundFee));
+        }
+        return _computePrices(longTotalBids, shortTotalBids, operation(deposited, value));
+    }
+
+    // Returns zero if the result would be negative. See the docs for the formulae this implements.
+    function bidOrRefundForPrice(
+        Side bidSide,
+        Side priceSide,
+        uint price,
+        bool refund
+    ) external view returns (uint) {
+        uint adjustedPrice = price.multiplyDecimalRound(_feeMultiplier);
+        uint bids = _option(priceSide).totalBids();
+        uint _deposited = deposited;
+        uint unit = SafeDecimalMath.unit();
+        uint refundFeeMultiplier = unit.sub(fees.refundFee);
+
+        if (bidSide == priceSide) {
+            uint depositedByPrice = _deposited.multiplyDecimalRound(adjustedPrice);
+
+            // For refunds, the numerator is the negative of the bid case and,
+            // in the denominator the adjusted price has an extra factor of (1 - the refundFee).
+            if (refund) {
+                (depositedByPrice, bids) = (bids, depositedByPrice);
+                adjustedPrice = adjustedPrice.multiplyDecimalRound(refundFeeMultiplier);
+            }
+
+            // The adjusted price is guaranteed to be less than 1: all its factors are also less than 1.
+            return _subToZero(depositedByPrice, bids).divideDecimalRound(unit.sub(adjustedPrice));
+        } else {
+            uint bidsPerPrice = bids.divideDecimalRound(adjustedPrice);
+
+            // For refunds, the numerator is the negative of the bid case.
+            if (refund) {
+                (bidsPerPrice, _deposited) = (_deposited, bidsPerPrice);
+            }
+
+            uint value = _subToZero(bidsPerPrice, _deposited);
+            return refund ? value.divideDecimalRound(refundFeeMultiplier) : value;
+        }
+    }
+
+    /* ---------- Option Balances and Bids ---------- */
+
+    function _bidsOf(address account) internal view returns (uint long, uint short) {
+        return (options.long.bidOf(account), options.short.bidOf(account));
+    }
+
+    function bidsOf(address account) external view returns (uint long, uint short) {
+        return _bidsOf(account);
+    }
+
+    function _totalBids() internal view returns (uint long, uint short) {
+        return (options.long.totalBids(), options.short.totalBids());
+    }
+
+    function totalBids() external view returns (uint long, uint short) {
+        return _totalBids();
+    }
+
+    function _claimableBalancesOf(address account) internal view returns (uint long, uint short) {
+        return (options.long.claimableBalanceOf(account), options.short.claimableBalanceOf(account));
+    }
+
+    function claimableBalancesOf(address account) external view returns (uint long, uint short) {
+        return _claimableBalancesOf(account);
+    }
+
+    function totalClaimableSupplies() external view returns (uint long, uint short) {
+        return (options.long.totalClaimableSupply(), options.short.totalClaimableSupply());
+    }
 
     function _balancesOf(address account) internal view returns (uint long, uint short) {
         return (options.long.balanceOf(account), options.short.balanceOf(account));
@@ -186,6 +342,15 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
 
     function totalSupplies() external view returns (uint long, uint short) {
         return (options.long.totalSupply(), options.short.totalSupply());
+    }
+
+    function _exercisableDeposits(uint _deposited) internal view returns (uint) {
+        // Fees are deducted at resolution, so remove them if we're still bidding or trading.
+        return resolved ? _deposited : _deposited.multiplyDecimalRound(_feeMultiplier);
+    }
+
+    function exercisableDeposits() external view returns (uint) {
+        return _exercisableDeposits(deposited);
     }
 
     /* ---------- Utilities ---------- */
@@ -213,6 +378,16 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
         return a < b ? 0 : a.sub(b);
     }
 
+    function _checkCreatorLimits(uint longBid, uint shortBid) internal view {
+        uint totalBid = longBid.add(shortBid);
+        require(creatorLimits.capitalRequirement <= totalBid, "Insufficient capital");
+        uint skewLimit = creatorLimits.skewLimit;
+        require(
+            skewLimit <= longBid.divideDecimal(totalBid) && skewLimit <= shortBid.divideDecimal(totalBid),
+            "Bids too skewed"
+        );
+    }
+
     function _incrementDeposited(uint value) internal returns (uint _deposited) {
         _deposited = deposited.add(value);
         deposited = _deposited;
@@ -229,38 +404,72 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
         require(!_manager().paused(), "This action cannot be performed while the contract is paused");
     }
 
-    function requireUnpaused() external view {
+    function requireActiveAndUnpaused() external view {
+        _systemStatus().requireSystemActive();
         _requireManagerNotPaused();
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */
 
-    /* ---------- Minting ---------- */
+    /* ---------- Bidding and Refunding ---------- */
 
-    function mint(uint value) external duringMinting {
+    function _updatePrices(
+        uint longBids,
+        uint shortBids,
+        uint _deposited
+    ) internal {
+        (uint256 longPrice, uint256 shortPrice) = _computePrices(longBids, shortBids, _deposited);
+        prices = Prices(longPrice, shortPrice);
+        emit PricesUpdated(longPrice, shortPrice);
+    }
+
+    function bid(Side side, uint value) external duringBidding {
         if (value == 0) {
             return;
         }
 
-        uint valueAfterFees = value.multiplyDecimalRound(_feeMultiplier);
+        _option(side).bid(msg.sender, value);
+        emit Bid(side, msg.sender, value);
 
-        _mint(msg.sender, valueAfterFees);
+        uint _deposited = _incrementDeposited(value);
+        _sUSD().transferFrom(msg.sender, address(this), value);
 
-        _incrementDeposited(value);
-        _manager().transferSusdTo(msg.sender, address(this), value);
+        (uint longTotalBids, uint shortTotalBids) = _totalBids();
+        _updatePrices(longTotalBids, shortTotalBids, _deposited);
     }
 
-    function _mint(address minter, uint amount) internal {
-        options.long.mint(minter, amount);
-        options.short.mint(minter, amount);
+    function refund(Side side, uint value) external duringBidding returns (uint refundMinusFee) {
+        require(refundsEnabled, "Refunds disabled");
+        if (value == 0) {
+            return 0;
+        }
 
-        emit Mint(Side.Long, minter, amount);
-        emit Mint(Side.Short, minter, amount);
+        // Require the market creator to leave sufficient capital in the market.
+        if (msg.sender == creator) {
+            (uint thisBid, uint thatBid) = _bidsOf(msg.sender);
+            if (side == Side.Short) {
+                (thisBid, thatBid) = (thatBid, thisBid);
+            }
+            _checkCreatorLimits(thisBid.sub(value), thatBid);
+        }
+
+        // Safe subtraction here and in related contracts will fail if either the
+        // total supply, deposits, or wallet balance are too small to support the refund.
+        refundMinusFee = value.multiplyDecimalRound(SafeDecimalMath.unit().sub(fees.refundFee));
+
+        _option(side).refund(msg.sender, value);
+        emit Refund(side, msg.sender, refundMinusFee, value.sub(refundMinusFee));
+
+        uint _deposited = _decrementDeposited(refundMinusFee);
+        _sUSD().transfer(msg.sender, refundMinusFee);
+
+        (uint longTotalBids, uint shortTotalBids) = _totalBids();
+        _updatePrices(longTotalBids, shortTotalBids, _deposited);
     }
 
     /* ---------- Market Resolution ---------- */
 
-    function resolve() external onlyOwner afterMaturity managerNotPaused {
+    function resolve() external onlyOwner afterMaturity systemActive managerNotPaused {
         require(!resolved, "Market already resolved");
 
         // We don't need to perform stale price checks, so long as the price was
@@ -276,11 +485,11 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
         // in the contract will be sufficient to cover these transfers.
         IERC20 sUSD = _sUSD();
 
-        uint _depositedSubMint = deposited.sub(initialMint);
-        uint poolFees = _depositedSubMint.multiplyDecimalRound(fees.poolFee);
-        uint creatorFees = _depositedSubMint.multiplyDecimalRound(fees.creatorFee);
+        uint _deposited = deposited;
+        uint poolFees = _deposited.multiplyDecimalRound(fees.poolFee);
+        uint creatorFees = _deposited.multiplyDecimalRound(fees.creatorFee);
         _decrementDeposited(creatorFees.add(poolFees));
-        sUSD.transfer(_manager().feeAddress(), poolFees);
+        sUSD.transfer(_feePool().FEE_ADDRESS(), poolFees);
         sUSD.transfer(creator, creatorFees);
 
         emit MarketResolved(_result(), price, updatedAt, deposited, poolFees, creatorFees);
@@ -288,11 +497,46 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
 
     /* ---------- Claiming and Exercising Options ---------- */
 
-    function exerciseOptions() external afterMaturity returns (uint) {
+    function _claimOptions()
+        internal
+        systemActive
+        managerNotPaused
+        afterBidding
+        returns (uint longClaimed, uint shortClaimed)
+    {
+        uint exercisable = _exercisableDeposits(deposited);
+        Side outcome = _result();
+        bool _resolved = resolved;
+
+        // Only claim options if we aren't resolved, and only claim the winning side.
+        uint longOptions;
+        uint shortOptions;
+        if (!_resolved || outcome == Side.Long) {
+            longOptions = options.long.claim(msg.sender, prices.long, exercisable);
+        }
+        if (!_resolved || outcome == Side.Short) {
+            shortOptions = options.short.claim(msg.sender, prices.short, exercisable);
+        }
+
+        require(longOptions != 0 || shortOptions != 0, "Nothing to claim");
+        emit OptionsClaimed(msg.sender, longOptions, shortOptions);
+        return (longOptions, shortOptions);
+    }
+
+    function claimOptions() external returns (uint longClaimed, uint shortClaimed) {
+        return _claimOptions();
+    }
+
+    function exerciseOptions() external returns (uint) {
         // The market must be resolved if it has not been.
-        // the first one to exercise pays the gas fees. Might be worth splitting it up.
         if (!resolved) {
             _manager().resolveMarket(address(this));
+        }
+
+        // If there are options to be claimed, claim them and proceed.
+        (uint claimableLong, uint claimableShort) = _claimableBalancesOf(msg.sender);
+        if (claimableLong != 0 || claimableShort != 0) {
+            _claimOptions();
         }
 
         // If the account holds no options, revert.
@@ -339,6 +583,14 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
         selfdestruct(beneficiary);
     }
 
+    function cancel(address payable beneficiary) external onlyOwner duringBidding {
+        (uint longTotalBids, uint shortTotalBids) = _totalBids();
+        (uint creatorLongBids, uint creatorShortBids) = _bidsOf(creator);
+        bool cancellable = longTotalBids == creatorLongBids && shortTotalBids == creatorShortBids;
+        require(cancellable, "Not cancellable");
+        _selfDestruct(beneficiary);
+    }
+
     function expire(address payable beneficiary) external onlyOwner {
         require(_expired(), "Unexpired options remaining");
         _selfDestruct(beneficiary);
@@ -346,13 +598,23 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
 
     /* ========== MODIFIERS ========== */
 
-    modifier duringMinting() {
-        require(!_matured(), "Minting inactive");
+    modifier duringBidding() {
+        require(!_biddingEnded(), "Bidding inactive");
+        _;
+    }
+
+    modifier afterBidding() {
+        require(_biddingEnded(), "Bidding incomplete");
         _;
     }
 
     modifier afterMaturity() {
         require(_matured(), "Not yet mature");
+        _;
+    }
+
+    modifier systemActive() {
+        _systemStatus().requireSystemActive();
         _;
     }
 
@@ -363,7 +625,9 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
 
     /* ========== EVENTS ========== */
 
-    event Mint(Side side, address indexed account, uint value);
+    event Bid(Side side, address indexed account, uint value);
+    event Refund(Side side, address indexed account, uint value, uint fee);
+    event PricesUpdated(uint longPrice, uint shortPrice);
     event MarketResolved(
         Side result,
         uint oraclePrice,
@@ -372,5 +636,6 @@ contract BinaryOptionMarket is MinimalProxyFactory, OwnedWithInit, IBinaryOption
         uint poolFees,
         uint creatorFees
     );
+    event OptionsClaimed(address indexed account, uint longOptions, uint shortOptions);
     event OptionsExercised(address indexed account, uint value);
 }

--- a/contracts/BinaryOptionMarket.sol
+++ b/contracts/BinaryOptionMarket.sol
@@ -15,7 +15,6 @@ import "./interfaces/IExchangeRates.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/IFeePool.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarket
 contract BinaryOptionMarket is Owned, MixinResolver, IBinaryOptionMarket {
     /* ========== LIBRARIES ========== */
 

--- a/contracts/BinaryOptionMarketData.sol
+++ b/contracts/BinaryOptionMarketData.sol
@@ -6,6 +6,7 @@ import "./BinaryOption.sol";
 import "./BinaryOptionMarket.sol";
 import "./BinaryOptionMarketManager.sol";
 
+// https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarketdata
 contract BinaryOptionMarketData {
     struct OptionValues {
         uint long;
@@ -14,6 +15,7 @@ contract BinaryOptionMarketData {
 
     struct Deposits {
         uint deposited;
+        uint exercisableDeposits;
     }
 
     struct Resolution {
@@ -33,57 +35,80 @@ contract BinaryOptionMarketData {
         BinaryOptionMarket.Times times;
         BinaryOptionMarket.OracleDetails oracleDetails;
         BinaryOptionMarketManager.Fees fees;
+        BinaryOptionMarketManager.CreatorLimits creatorLimits;
     }
 
     struct MarketData {
         OraclePriceAndTimestamp oraclePriceAndTimestamp;
+        BinaryOptionMarket.Prices prices;
         Deposits deposits;
         Resolution resolution;
         BinaryOptionMarket.Phase phase;
         BinaryOptionMarket.Side result;
+        OptionValues totalBids;
+        OptionValues totalClaimableSupplies;
         OptionValues totalSupplies;
     }
 
     struct AccountData {
+        OptionValues bids;
+        OptionValues claimable;
         OptionValues balances;
     }
 
     function getMarketParameters(BinaryOptionMarket market) public view returns (MarketParameters memory) {
         (BinaryOption long, BinaryOption short) = market.options();
-        (uint maturityDate, uint expiryDate) = market.times();
+        (uint biddingEndDate, uint maturityDate, uint expiryDate) = market.times();
         (bytes32 key, uint strikePrice, uint finalPrice) = market.oracleDetails();
-        (uint poolFee, uint creatorFee) = market.fees();
+        (uint poolFee, uint creatorFee, uint refundFee) = market.fees();
 
         MarketParameters memory data =
             MarketParameters(
                 market.creator(),
                 BinaryOptionMarket.Options(long, short),
-                BinaryOptionMarket.Times(maturityDate, expiryDate),
+                BinaryOptionMarket.Times(biddingEndDate, maturityDate, expiryDate),
                 BinaryOptionMarket.OracleDetails(key, strikePrice, finalPrice),
-                BinaryOptionMarketManager.Fees(poolFee, creatorFee)
+                BinaryOptionMarketManager.Fees(poolFee, creatorFee, refundFee),
+                BinaryOptionMarketManager.CreatorLimits(0, 0)
             );
 
+        // Stack too deep otherwise.
+        (uint capitalRequirement, uint skewLimit) = market.creatorLimits();
+        data.creatorLimits = BinaryOptionMarketManager.CreatorLimits(capitalRequirement, skewLimit);
         return data;
     }
 
     function getMarketData(BinaryOptionMarket market) public view returns (MarketData memory) {
         (uint price, uint updatedAt) = market.oraclePriceAndTimestamp();
+        (uint longClaimable, uint shortClaimable) = market.totalClaimableSupplies();
         (uint longSupply, uint shortSupply) = market.totalSupplies();
+        (uint longBids, uint shortBids) = market.totalBids();
+        (uint longPrice, uint shortPrice) = market.prices();
 
         return
             MarketData(
                 OraclePriceAndTimestamp(price, updatedAt),
-                Deposits(market.deposited()),
+                BinaryOptionMarket.Prices(longPrice, shortPrice),
+                Deposits(market.deposited(), market.exercisableDeposits()),
                 Resolution(market.resolved(), market.canResolve()),
                 market.phase(),
                 market.result(),
+                OptionValues(longBids, shortBids),
+                OptionValues(longClaimable, shortClaimable),
                 OptionValues(longSupply, shortSupply)
             );
     }
 
     function getAccountMarketData(BinaryOptionMarket market, address account) public view returns (AccountData memory) {
+        (uint longBid, uint shortBid) = market.bidsOf(account);
+        (uint longClaimable, uint shortClaimable) = market.claimableBalancesOf(account);
         (uint longBalance, uint shortBalance) = market.balancesOf(account);
 
-        return AccountData(OptionValues(longBalance, shortBalance));
+        return
+            AccountData(
+                OptionValues(longBid, shortBid),
+                OptionValues(longClaimable, shortClaimable),
+                OptionValues(longBalance, shortBalance)
+            );
     }
 }

--- a/contracts/BinaryOptionMarketData.sol
+++ b/contracts/BinaryOptionMarketData.sol
@@ -6,7 +6,6 @@ import "./BinaryOption.sol";
 import "./BinaryOptionMarket.sol";
 import "./BinaryOptionMarketManager.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarketdata
 contract BinaryOptionMarketData {
     struct OptionValues {
         uint long;

--- a/contracts/BinaryOptionMarketFactory.sol
+++ b/contracts/BinaryOptionMarketFactory.sol
@@ -7,7 +7,6 @@ import "./MixinResolver.sol";
 // Internal references
 import "./BinaryOptionMarket.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarketfactory
 contract BinaryOptionMarketFactory is Owned, MixinResolver {
     /* ========== STATE VARIABLES ========== */
 

--- a/contracts/BinaryOptionMarketManager.sol
+++ b/contracts/BinaryOptionMarketManager.sol
@@ -18,7 +18,6 @@ import "./interfaces/IExchangeRates.sol";
 import "./interfaces/ISystemStatus.sol";
 import "./interfaces/IERC20.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarketmanager
 contract BinaryOptionMarketManager is Owned, Pausable, MixinResolver, IBinaryOptionMarketManager {
     /* ========== LIBRARIES ========== */
 

--- a/contracts/interfaces/IBinaryOption.sol
+++ b/contracts/interfaces/IBinaryOption.sol
@@ -1,7 +1,7 @@
 pragma solidity >=0.4.24;
 
 import "../interfaces/IBinaryOptionMarket.sol";
-import "synthetix-2.43.1/contracts/interfaces/IERC20.sol";
+import "../interfaces/IERC20.sol";
 
 // https://docs.synthetix.io/contracts/source/interfaces/ibinaryoption
 interface IBinaryOption {
@@ -9,8 +9,15 @@ interface IBinaryOption {
 
     function market() external view returns (IBinaryOptionMarket);
 
+    function bidOf(address account) external view returns (uint);
+
+    function totalBids() external view returns (uint);
+
     function balanceOf(address account) external view returns (uint);
 
     function totalSupply() external view returns (uint);
 
+    function claimableBalanceOf(address account) external view returns (uint);
+
+    function totalClaimableSupply() external view returns (uint);
 }

--- a/contracts/interfaces/IBinaryOption.sol
+++ b/contracts/interfaces/IBinaryOption.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.4.24;
 import "../interfaces/IBinaryOptionMarket.sol";
 import "../interfaces/IERC20.sol";
 
-// https://docs.synthetix.io/contracts/source/interfaces/ibinaryoption
 interface IBinaryOption {
     /* ========== VIEWS / VARIABLES ========== */
 

--- a/contracts/interfaces/IBinaryOptionMarket.sol
+++ b/contracts/interfaces/IBinaryOptionMarket.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.4.24;
 import "../interfaces/IBinaryOptionMarketManager.sol";
 import "../interfaces/IBinaryOption.sol";
 
-// https://docs.synthetix.io/contracts/source/interfaces/ibinaryoptionmarket
 interface IBinaryOptionMarket {
     /* ========== TYPES ========== */
 

--- a/contracts/interfaces/IBinaryOptionMarket.sol
+++ b/contracts/interfaces/IBinaryOptionMarket.sol
@@ -7,17 +7,20 @@ import "../interfaces/IBinaryOption.sol";
 interface IBinaryOptionMarket {
     /* ========== TYPES ========== */
 
-    enum Phase {Trading, Maturity, Expiry}
+    enum Phase {Bidding, Trading, Maturity, Expiry}
     enum Side {Long, Short}
 
     /* ========== VIEWS / VARIABLES ========== */
 
     function options() external view returns (IBinaryOption long, IBinaryOption short);
 
+    function prices() external view returns (uint long, uint short);
+
     function times()
         external
         view
         returns (
+            uint biddingEnd,
             uint maturity,
             uint destructino
         );
@@ -36,14 +39,19 @@ interface IBinaryOptionMarket {
         view
         returns (
             uint poolFee,
-            uint creatorFee
+            uint creatorFee,
+            uint refundFee
         );
+
+    function creatorLimits() external view returns (uint capitalRequirement, uint skewLimit);
 
     function deposited() external view returns (uint);
 
     function creator() external view returns (address);
 
     function resolved() external view returns (bool);
+
+    function refundsEnabled() external view returns (bool);
 
     function phase() external view returns (Phase);
 
@@ -53,13 +61,40 @@ interface IBinaryOptionMarket {
 
     function result() external view returns (Side);
 
+    function pricesAfterBidOrRefund(
+        Side side,
+        uint value,
+        bool refund
+    ) external view returns (uint long, uint short);
+
+    function bidOrRefundForPrice(
+        Side bidSide,
+        Side priceSide,
+        uint price,
+        bool refund
+    ) external view returns (uint);
+
+    function bidsOf(address account) external view returns (uint long, uint short);
+
+    function totalBids() external view returns (uint long, uint short);
+
+    function claimableBalancesOf(address account) external view returns (uint long, uint short);
+
+    function totalClaimableSupplies() external view returns (uint long, uint short);
+
     function balancesOf(address account) external view returns (uint long, uint short);
 
     function totalSupplies() external view returns (uint long, uint short);
 
+    function exercisableDeposits() external view returns (uint);
+
     /* ========== MUTATIVE FUNCTIONS ========== */
 
-    function mint(uint value) external;
+    function bid(Side side, uint value) external;
+
+    function refund(Side side, uint value) external returns (uint refundMinusFee);
+
+    function claimOptions() external returns (uint longClaimed, uint shortClaimed);
 
     function exerciseOptions() external returns (uint);
 }

--- a/contracts/interfaces/IBinaryOptionMarketManager.sol
+++ b/contracts/interfaces/IBinaryOptionMarketManager.sol
@@ -2,7 +2,6 @@ pragma solidity >=0.4.24;
 
 import "../interfaces/IBinaryOptionMarket.sol";
 
-// https://docs.synthetix.io/contracts/source/interfaces/ibinaryoptionmarketmanager
 interface IBinaryOptionMarketManager {
     /* ========== VIEWS / VARIABLES ========== */
 

--- a/contracts/interfaces/IBinaryOptionMarketManager.sol
+++ b/contracts/interfaces/IBinaryOptionMarketManager.sol
@@ -6,7 +6,14 @@ import "../interfaces/IBinaryOptionMarket.sol";
 interface IBinaryOptionMarketManager {
     /* ========== VIEWS / VARIABLES ========== */
 
-    function fees() external view returns (uint poolFee, uint creatorFee);
+    function fees()
+        external
+        view
+        returns (
+            uint poolFee,
+            uint creatorFee,
+            uint refundFee
+        );
 
     function durations()
         external
@@ -17,7 +24,7 @@ interface IBinaryOptionMarketManager {
             uint maxTimeToMaturity
         );
 
-    function capitalRequirement() external view returns (uint);
+    function creatorLimits() external view returns (uint capitalRequirement, uint skewLimit);
 
     function marketCreationEnabled() external view returns (bool);
 
@@ -36,13 +43,14 @@ interface IBinaryOptionMarketManager {
     function createMarket(
         bytes32 oracleKey,
         uint strikePrice,
-        uint maturity,
-        uint initialMint // initial sUSD to mint options for
+        bool refundsEnabled,
+        uint[2] calldata times, // [biddingEnd, maturity]
+        uint[2] calldata bids // [longBid, shortBid]
     ) external returns (IBinaryOptionMarket);
 
     function resolveMarket(address market) external;
 
-    function expireMarkets(address[] calldata market) external;
+    function cancelMarket(address market) external;
 
-    function transferSusdTo(address sender, address receiver, uint amount) external;
+    function expireMarkets(address[] calldata market) external;
 }


### PR DESCRIPTION
A pull request to depict the differences between the Thales model and the original Synthetix model.
To sum up the differences:

- Bidding phase is removed
- For every sUSD deposited into a binary market the user gets 1 long option and 1 short option
- Options can be traded as soon as the market is created up until maturity
- Anyone can mint more options by depositing the adequate amount of sUSD
- Refunds are cancelations are removed as those were only possible during bidding phase