### PR TITLE
Revert "Bump @openzeppelin/contracts-upgradeable from 4.4.1 to 4.7.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,15 @@
 				"codecov": "^3.8.3",
 				"dotenv": "^6.1.0",
 				"eslint": "7.6.0",
+				"eslint-config-prettier": "^3.6.0",
+				"eslint-config-standard": "^12.0.0",
+				"eslint-plugin-havven": "^1.0.0",
+				"eslint-plugin-import": "2.22.0",
+				"eslint-plugin-no-only-tests": "^2.4.0",
+				"eslint-plugin-node": "11.1.0",
+				"eslint-plugin-prettier": "^2.6.2",
+				"eslint-plugin-promise": "^4.0.1",
+				"eslint-plugin-standard": "^4.0.0",
 				"ethers": "^5.5.1",
 				"hardhat": "~2.1.2",
 				"hardhat-gas-reporter": "~1.0.4",
@@ -2871,9 +2880,9 @@
 			"integrity": "sha512-o+pHCf/yMLSlV5MkDQEzEQL402i6SoRnktru+0rdSxVEFZcTzzGhZCAtZjUFyKGazMSv1TilzMg+RbED1N8XHQ=="
 		},
 		"node_modules/@openzeppelin/contracts-upgradeable": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.1.tgz",
-			"integrity": "sha512-5EFiZld3DYFd8aTL8eeMnhnaWh1/oXLXFNuFMrgF3b1DNPshF3LCyO7VR6lc+gac2URJ0BlVcZoCfkk/3MoEfg=="
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.1.tgz",
+			"integrity": "sha512-84dUN+TBY42D52BzUc4RHxU4KORs8Ys7dj3nH0WX1QKtlS6rrN45gL+sxaotkPdCqFLVLPyj+kd8GfJ4puxVjA=="
 		},
 		"node_modules/@openzeppelin/hardhat-upgrades": {
 			"version": "1.12.0",
@@ -5530,6 +5539,24 @@
 			"version": "1.1.1",
 			"license": "MIT"
 		},
+		"node_modules/array-includes": {
+			"version": "3.1.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.2",
+				"get-intrinsic": "^1.1.1",
+				"is-string": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
 			"dev": true,
@@ -5551,6 +5578,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/array.prototype.flat": {
+			"version": "1.2.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/asap": {
@@ -6850,6 +6893,14 @@
 			"version": "1.0.0",
 			"license": "MIT"
 		},
+		"node_modules/contains-path": {
+			"version": "0.1.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/content-disposition": {
 			"version": "0.5.3",
 			"license": "MIT",
@@ -7910,6 +7961,240 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-config-prettier": {
+			"version": "3.6.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-stdin": "^6.0.0"
+			},
+			"bin": {
+				"eslint-config-prettier-check": "bin/cli.js"
+			},
+			"peerDependencies": {
+				"eslint": ">=3.14.1"
+			}
+		},
+		"node_modules/eslint-config-standard": {
+			"version": "12.0.0",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"eslint": ">=5.0.0",
+				"eslint-plugin-import": ">=2.13.0",
+				"eslint-plugin-node": ">=7.0.0",
+				"eslint-plugin-promise": ">=4.0.0",
+				"eslint-plugin-standard": ">=4.0.0"
+			}
+		},
+		"node_modules/eslint-import-resolver-node": {
+			"version": "0.3.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^2.6.9",
+				"resolve": "^1.13.1"
+			}
+		},
+		"node_modules/eslint-import-resolver-node/node_modules/debug": {
+			"version": "2.6.9",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/eslint-import-resolver-node/node_modules/ms": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/eslint-module-utils": {
+			"version": "2.6.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^3.2.7",
+				"pkg-dir": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/eslint-module-utils/node_modules/debug": {
+			"version": "3.2.7",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-plugin-es": {
+			"version": "3.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-utils": "^2.0.0",
+				"regexpp": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=4.19.1"
+			}
+		},
+		"node_modules/eslint-plugin-havven": {
+			"version": "1.1.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/eslint-plugin-import": {
+			"version": "2.22.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-includes": "^3.1.1",
+				"array.prototype.flat": "^1.2.3",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.9",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "^0.3.3",
+				"eslint-module-utils": "^2.6.0",
+				"has": "^1.0.3",
+				"minimatch": "^3.0.4",
+				"object.values": "^1.1.1",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.17.0",
+				"tsconfig-paths": "^3.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependencies": {
+				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/debug": {
+			"version": "2.6.9",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/doctrine": {
+			"version": "1.5.0",
+			"dev": true,
+			"dependencies": {
+				"esutils": "^2.0.2",
+				"isarray": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/isarray": {
+			"version": "1.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/eslint-plugin-import/node_modules/ms": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/eslint-plugin-no-only-tests": {
+			"version": "2.6.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-node": {
+			"version": "11.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-plugin-es": "^3.0.0",
+				"eslint-utils": "^2.0.0",
+				"ignore": "^5.1.1",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.10.1",
+				"semver": "^6.1.0"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=5.16.0"
+			}
+		},
+		"node_modules/eslint-plugin-node/node_modules/ignore": {
+			"version": "5.1.8",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/eslint-plugin-node/node_modules/semver": {
+			"version": "6.3.0",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/eslint-plugin-prettier": {
+			"version": "2.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-diff": "^1.1.1",
+				"jest-docblock": "^21.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			},
+			"peerDependencies": {
+				"prettier": ">= 0.11.0"
+			}
+		},
+		"node_modules/eslint-plugin-promise": {
+			"version": "4.3.1",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/eslint-plugin-standard": {
+			"version": "4.1.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"eslint": ">=5.0.0"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -15169,6 +15454,14 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/get-stdin": {
+			"version": "6.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/get-stream": {
 			"version": "5.2.0",
 			"license": "MIT",
@@ -17245,6 +17538,11 @@
 			"version": "1.3.0",
 			"license": "MIT"
 		},
+		"node_modules/jest-docblock": {
+			"version": "21.2.0",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/js-levenshtein": {
 			"version": "1.1.6",
 			"license": "MIT",
@@ -17317,7 +17615,6 @@
 			"version": "2.2.0",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"minimist": "^1.2.5"
 			},
@@ -18965,6 +19262,22 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/object.values": {
+			"version": "1.1.4",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/objects-to-csv": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/objects-to-csv/-/objects-to-csv-1.3.6.tgz",
@@ -19515,6 +19828,59 @@
 		"node_modules/pino-std-serializers": {
 			"version": "3.2.0",
 			"license": "MIT"
+		},
+		"node_modules/pkg-dir": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/find-up": {
+			"version": "2.1.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/locate-path": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/p-locate": {
+			"version": "2.0.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/path-exists": {
+			"version": "3.0.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/posix-character-classes": {
 			"version": "0.1.1",
@@ -22819,6 +23185,16 @@
 			},
 			"peerDependencies": {
 				"typescript": ">=2.7"
+			}
+		},
+		"node_modules/tsconfig-paths": {
+			"version": "3.10.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json5": "^2.2.0",
+				"minimist": "^1.2.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"node_modules/tslib": {
@@ -27582,9 +27958,9 @@
 			"integrity": "sha512-o+pHCf/yMLSlV5MkDQEzEQL402i6SoRnktru+0rdSxVEFZcTzzGhZCAtZjUFyKGazMSv1TilzMg+RbED1N8XHQ=="
 		},
 		"@openzeppelin/contracts-upgradeable": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.1.tgz",
-			"integrity": "sha512-5EFiZld3DYFd8aTL8eeMnhnaWh1/oXLXFNuFMrgF3b1DNPshF3LCyO7VR6lc+gac2URJ0BlVcZoCfkk/3MoEfg=="
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.1.tgz",
+			"integrity": "sha512-84dUN+TBY42D52BzUc4RHxU4KORs8Ys7dj3nH0WX1QKtlS6rrN45gL+sxaotkPdCqFLVLPyj+kd8GfJ4puxVjA=="
 		},
 		"@openzeppelin/hardhat-upgrades": {
 			"version": "1.12.0",
@@ -29650,6 +30026,17 @@
 		"array-flatten": {
 			"version": "1.1.1"
 		},
+		"array-includes": {
+			"version": "3.1.3",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.2",
+				"get-intrinsic": "^1.1.1",
+				"is-string": "^1.0.5"
+			}
+		},
 		"array-union": {
 			"version": "2.1.0",
 			"dev": true
@@ -29660,6 +30047,15 @@
 		"array-unique": {
 			"version": "0.3.2",
 			"devOptional": true
+		},
+		"array.prototype.flat": {
+			"version": "1.2.4",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.1"
+			}
 		},
 		"asap": {
 			"version": "2.0.6",
@@ -30589,6 +30985,10 @@
 		"constants-browserify": {
 			"version": "1.0.0"
 		},
+		"contains-path": {
+			"version": "0.1.0",
+			"dev": true
+		},
 		"content-disposition": {
 			"version": "0.5.3",
 			"requires": {
@@ -31386,6 +31786,155 @@
 					}
 				}
 			}
+		},
+		"eslint-config-prettier": {
+			"version": "3.6.0",
+			"dev": true,
+			"requires": {
+				"get-stdin": "^6.0.0"
+			}
+		},
+		"eslint-config-standard": {
+			"version": "12.0.0",
+			"dev": true,
+			"requires": {}
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.4",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"resolve": "^1.13.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"dev": true
+				}
+			}
+		},
+		"eslint-module-utils": {
+			"version": "2.6.1",
+			"dev": true,
+			"requires": {
+				"debug": "^3.2.7",
+				"pkg-dir": "^2.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.7",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
+		"eslint-plugin-es": {
+			"version": "3.0.1",
+			"dev": true,
+			"requires": {
+				"eslint-utils": "^2.0.0",
+				"regexpp": "^3.0.0"
+			}
+		},
+		"eslint-plugin-havven": {
+			"version": "1.1.0",
+			"dev": true
+		},
+		"eslint-plugin-import": {
+			"version": "2.22.0",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.1.1",
+				"array.prototype.flat": "^1.2.3",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.9",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "^0.3.3",
+				"eslint-module-utils": "^2.6.0",
+				"has": "^1.0.3",
+				"minimatch": "^3.0.4",
+				"object.values": "^1.1.1",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.17.0",
+				"tsconfig-paths": "^3.9.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "1.5.0",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.0.0",
+					"dev": true
+				}
+			}
+		},
+		"eslint-plugin-no-only-tests": {
+			"version": "2.6.0",
+			"dev": true
+		},
+		"eslint-plugin-node": {
+			"version": "11.1.0",
+			"dev": true,
+			"requires": {
+				"eslint-plugin-es": "^3.0.0",
+				"eslint-utils": "^2.0.0",
+				"ignore": "^5.1.1",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.10.1",
+				"semver": "^6.1.0"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "5.1.8",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"dev": true
+				}
+			}
+		},
+		"eslint-plugin-prettier": {
+			"version": "2.7.0",
+			"dev": true,
+			"requires": {
+				"fast-diff": "^1.1.1",
+				"jest-docblock": "^21.0.0"
+			}
+		},
+		"eslint-plugin-promise": {
+			"version": "4.3.1",
+			"dev": true
+		},
+		"eslint-plugin-standard": {
+			"version": "4.1.0",
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
@@ -36957,6 +37506,10 @@
 			"version": "3.2.0",
 			"dev": true
 		},
+		"get-stdin": {
+			"version": "6.0.0",
+			"dev": true
+		},
 		"get-stream": {
 			"version": "5.2.0",
 			"requires": {
@@ -38282,6 +38835,10 @@
 		"iterall": {
 			"version": "1.3.0"
 		},
+		"jest-docblock": {
+			"version": "21.2.0",
+			"dev": true
+		},
 		"js-levenshtein": {
 			"version": "1.1.6"
 		},
@@ -38335,7 +38892,6 @@
 		"json5": {
 			"version": "2.2.0",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -39551,6 +40107,15 @@
 				"isobject": "^3.0.1"
 			}
 		},
+		"object.values": {
+			"version": "1.1.4",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.2"
+			}
+		},
 		"objects-to-csv": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/objects-to-csv/-/objects-to-csv-1.3.6.tgz",
@@ -39916,6 +40481,41 @@
 		},
 		"pino-std-serializers": {
 			"version": "3.2.0"
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"dev": true
+				}
+			}
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
@@ -42198,6 +42798,15 @@
 				"make-error": "^1.1.1",
 				"source-map-support": "^0.5.17",
 				"yn": "3.1.1"
+			}
+		},
+		"tsconfig-paths": {
+			"version": "3.10.1",
+			"dev": true,
+			"requires": {
+				"json5": "^2.2.0",
+				"minimist": "^1.2.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"tslib": {


### PR DESCRIPTION
This reverts commit f9519592a680d5968870d89babb0574034c8321b.