### PR TITLE
Cooling down Exotic markets

### DIFF
--- a/.openzeppelin/unknown-10.json
+++ b/.openzeppelin/unknown-10.json
@@ -11960,25 +11960,25 @@
             "contract": "ProxyOwned",
             "label": "owner",
             "type": "t_address",
-            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:6"
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:7"
           },
           {
             "contract": "ProxyOwned",
             "label": "nominatedOwner",
             "type": "t_address",
-            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:7"
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:8"
           },
           {
             "contract": "ProxyOwned",
             "label": "_initialized",
             "type": "t_bool",
-            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:8"
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:9"
           },
           {
             "contract": "ProxyOwned",
             "label": "_transferredAtInit",
             "type": "t_bool",
-            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:9"
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:10"
           },
           {
             "contract": "ContextUpgradeable",
@@ -12002,113 +12002,113 @@
             "contract": "ProxyReentrancyGuard",
             "label": "_guardCounter",
             "type": "t_uint256",
-            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyReentrancyGuard.sol:18"
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyReentrancyGuard.sol:19"
           },
           {
             "contract": "ProxyReentrancyGuard",
             "label": "_initialized",
             "type": "t_bool",
-            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyReentrancyGuard.sol:19"
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyReentrancyGuard.sol:20"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "marketManager",
-            "type": "t_contract(IExoticPositionalMarketManager)41681",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:42"
+            "type": "t_contract(IExoticPositionalMarketManager)73747",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:44"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "councilMemberCount",
             "type": "t_uint256",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:43"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:45"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "councilMemberAddress",
             "type": "t_mapping(t_uint256,t_address)",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:44"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:46"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "councilMemberIndex",
             "type": "t_mapping(t_address,t_uint256)",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:45"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:47"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "marketTotalDisputes",
             "type": "t_mapping(t_address,t_uint256)",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:46"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:48"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "marketLastClosedDispute",
             "type": "t_mapping(t_address,t_uint256)",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:47"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:49"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "allOpenDisputesCancelledToIndexForMarket",
             "type": "t_mapping(t_address,t_uint256)",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:48"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:50"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "marketOpenDisputesCount",
             "type": "t_mapping(t_address,t_uint256)",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:49"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:51"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "marketClosedForDisputes",
             "type": "t_mapping(t_address,t_bool)",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:50"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:52"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "firstMemberThatChoseWinningPosition",
             "type": "t_mapping(t_address,t_address)",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:51"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:53"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "dispute",
-            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Dispute)24061_storage))",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:53"
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Dispute)28738_storage))",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:55"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "disputeVote",
             "type": "t_mapping(t_address,t_mapping(t_uint256,t_array(t_uint256)dyn_storage))",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:54"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:56"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "disputeVotesCount",
             "type": "t_mapping(t_address,t_mapping(t_uint256,t_array(t_uint256)7_storage))",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:55"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:57"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "disputeWinningPositionChoosen",
             "type": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:56"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:58"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "disputeWinningPositionChoosenByMember",
             "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_uint256)))",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:57"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:59"
           },
           {
             "contract": "ThalesOracleCouncil",
             "label": "disputeWinningPositionVotes",
             "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_uint256,t_uint256)))",
-            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:58"
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:60"
           }
         ],
         "types": {
-          "t_contract(IExoticPositionalMarketManager)41681": {
+          "t_contract(IExoticPositionalMarketManager)73747": {
             "label": "contract IExoticPositionalMarketManager"
           },
           "t_uint256": {
@@ -12132,13 +12132,13 @@
           "t_mapping(t_address,t_address)": {
             "label": "mapping(address => address)"
           },
-          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Dispute)24061_storage))": {
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Dispute)28738_storage))": {
             "label": "mapping(address => mapping(uint256 => struct ThalesOracleCouncil.Dispute))"
           },
-          "t_mapping(t_uint256,t_struct(Dispute)24061_storage)": {
+          "t_mapping(t_uint256,t_struct(Dispute)28738_storage)": {
             "label": "mapping(uint256 => struct ThalesOracleCouncil.Dispute)"
           },
-          "t_struct(Dispute)24061_storage": {
+          "t_struct(Dispute)28738_storage": {
             "label": "struct ThalesOracleCouncil.Dispute",
             "members": [
               {
@@ -39911,6 +39911,278 @@
           },
           "t_bool": {
             "label": "bool"
+          }
+        }
+      }
+    },
+    "d0eb638ef151c42f6d1e7809ea53617bd6c1ac045482de45c5be1a25f7ef2e87": {
+      "address": "0x1d70B630303ad656697719B5eC78b93855236324",
+      "txHash": "0xee607f300a03312a4aa8768b4f43f0d509c233a04a78cdc317e33abea51b9ae9",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "ProxyOwned",
+            "label": "owner",
+            "type": "t_address",
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:7"
+          },
+          {
+            "contract": "ProxyOwned",
+            "label": "nominatedOwner",
+            "type": "t_address",
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:8"
+          },
+          {
+            "contract": "ProxyOwned",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:9"
+          },
+          {
+            "contract": "ProxyOwned",
+            "label": "_transferredAtInit",
+            "type": "t_bool",
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyOwned.sol:10"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "_paused",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:97"
+          },
+          {
+            "contract": "ProxyReentrancyGuard",
+            "label": "_guardCounter",
+            "type": "t_uint256",
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyReentrancyGuard.sol:19"
+          },
+          {
+            "contract": "ProxyReentrancyGuard",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "contracts/utils/proxy/solidity-0.8.0/ProxyReentrancyGuard.sol:20"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "marketManager",
+            "type": "t_contract(IExoticPositionalMarketManager)68603",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:44"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "councilMemberCount",
+            "type": "t_uint256",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:45"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "councilMemberAddress",
+            "type": "t_mapping(t_uint256,t_address)",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:46"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "councilMemberIndex",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:47"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "marketTotalDisputes",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:48"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "marketLastClosedDispute",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:49"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "allOpenDisputesCancelledToIndexForMarket",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:50"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "marketOpenDisputesCount",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:51"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "marketClosedForDisputes",
+            "type": "t_mapping(t_address,t_bool)",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:52"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "firstMemberThatChoseWinningPosition",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:53"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "dispute",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Dispute)28704_storage))",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:55"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "disputeVote",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_array(t_uint256)dyn_storage))",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:56"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "disputeVotesCount",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_array(t_uint256)7_storage))",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:57"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "disputeWinningPositionChoosen",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:58"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "disputeWinningPositionChoosenByMember",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_uint256)))",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:59"
+          },
+          {
+            "contract": "ThalesOracleCouncil",
+            "label": "disputeWinningPositionVotes",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_uint256,t_uint256)))",
+            "src": "contracts/ExoticPositionalMarkets/ThalesOracleCouncil.sol:60"
+          }
+        ],
+        "types": {
+          "t_contract(IExoticPositionalMarketManager)68603": {
+            "label": "contract IExoticPositionalMarketManager"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Dispute)28704_storage))": {
+            "label": "mapping(address => mapping(uint256 => struct ThalesOracleCouncil.Dispute))"
+          },
+          "t_mapping(t_uint256,t_struct(Dispute)28704_storage)": {
+            "label": "mapping(uint256 => struct ThalesOracleCouncil.Dispute)"
+          },
+          "t_struct(Dispute)28704_storage": {
+            "label": "struct ThalesOracleCouncil.Dispute",
+            "members": [
+              {
+                "label": "disputorAddress",
+                "type": "t_address"
+              },
+              {
+                "label": "disputeString",
+                "type": "t_string_storage"
+              },
+              {
+                "label": "disputeCode",
+                "type": "t_uint256"
+              },
+              {
+                "label": "disputeTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "disputeInPositioningPhase",
+                "type": "t_bool"
+              }
+            ]
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_array(t_uint256)dyn_storage))": {
+            "label": "mapping(address => mapping(uint256 => uint256[]))"
+          },
+          "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)": {
+            "label": "mapping(uint256 => uint256[])"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_array(t_uint256)7_storage))": {
+            "label": "mapping(address => mapping(uint256 => uint256[7]))"
+          },
+          "t_mapping(t_uint256,t_array(t_uint256)7_storage)": {
+            "label": "mapping(uint256 => uint256[7])"
+          },
+          "t_array(t_uint256)7_storage": {
+            "label": "uint256[7]"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(address => mapping(uint256 => uint256))"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_uint256)))": {
+            "label": "mapping(address => mapping(uint256 => mapping(address => uint256)))"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(uint256 => mapping(address => uint256))"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_uint256,t_uint256)))": {
+            "label": "mapping(address => mapping(uint256 => mapping(uint256 => uint256)))"
+          },
+          "t_mapping(t_uint256,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(uint256 => mapping(uint256 => uint256))"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
           }
         }
       }

--- a/scripts/deployments.json
+++ b/scripts/deployments.json
@@ -43,7 +43,7 @@
 		"ExoticMarketManager": "0x9a51524422DDF1B8AfEc04CBa6451a6c50320998",
 		"ExoticMarketManagerImplementation": "0x0fA6b2516ce46013182f3F1F31aa7bfb04FD409B",
 		"ThalesOracleCouncil": "0xDF3eefC2ED0F31947a67f0e817DfD92717630E38",
-		"ThalesOracleCouncilImplementation": "0x717eE7991Cfeeb79B1D8E7d1DBD982fb7982d0fD",
+		"ThalesOracleCouncilImplementation": "0x1d70B630303ad656697719B5eC78b93855236324",
 		"ThalesBonds": "0x160Ca569999601bca06109D42d561D85D6Bb4b57",
 		"ThalesBondsImplementation": "0xC45Eb8d37917AB65D06806F35cC54e09dea135AC",
 		"ExoticMarketMasterCopy": "0x14f05E3A555b1DC833e549e5625Fd0a05E76eBd2",


### PR DESCRIPTION
- new deployment for Oracle Council to avoid revert on pDAO address additions