### PR TITLE
Add constructor with initializer for implementation contracts

### DIFF
--- a/contracts/SportMarkets/LiquidityPool/SportAMMLiquidityPool.sol
+++ b/contracts/SportMarkets/LiquidityPool/SportAMMLiquidityPool.sol
@@ -88,6 +88,9 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
 
     /* ========== CONSTRUCTOR ========== */
 
+    // Initializes the implementation contract to avoid potential foul-play
+    constructor() initializer {}
+
     function initialize(InitParams calldata params) external initializer {
         setOwner(params._owner);
         initNonReentrant();


### PR DESCRIPTION
## Changes
- Add constructor with `initializer` modifier to SportsAMMLiquidityPool contract (as a demo)