### PR TITLE
apply audit suggestions

### DIFF
--- a/contracts/SportMarkets/LiquidityPool/DefaultLiquidityProvider.sol
+++ b/contracts/SportMarkets/LiquidityPool/DefaultLiquidityProvider.sol
@@ -18,6 +18,11 @@ contract DefaultLiquidityProvider is ProxyOwned, Initializable, ProxyReentrancyG
     /// @return the adddress of the AMMLP contract
     address public liquidityPool;
 
+    //    /// @custom:oz-upgrades-unsafe-allow constructor
+    //    constructor() {
+    //        _disableInitializers();
+    //    }
+
     function initialize(
         address _owner,
         IERC20Upgradeable _sUSD,

--- a/contracts/SportMarkets/LiquidityPool/SportAMMLiquidityPool.sol
+++ b/contracts/SportMarkets/LiquidityPool/SportAMMLiquidityPool.sol
@@ -28,6 +28,7 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
         uint _maxAllowedDeposit;
         uint _minDepositAmount;
         uint _maxAllowedUsers;
+        bool _needsTransformingCollateral;
     }
 
     /* ========== CONSTANTS ========== */
@@ -92,6 +93,11 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
 
     /* ========== CONSTRUCTOR ========== */
 
+    //    /// @custom:oz-upgrades-unsafe-allow constructor
+    //    constructor() {
+    //        _disableInitializers();
+    //    }
+
     function initialize(InitParams calldata params) external initializer {
         setOwner(params._owner);
         initNonReentrant();
@@ -103,6 +109,8 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
         minDepositAmount = params._minDepositAmount;
         maxAllowedUsers = params._maxAllowedUsers;
 
+        needsTransformingCollateral = params._needsTransformingCollateral;
+
         sUSD.approve(address(sportsAMM), type(uint256).max);
     }
 
@@ -110,8 +118,13 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
     function start() external onlyOwner {
         require(!started, "Liquidity pool has already started");
         require(allocationPerRound[1] > 0, "can not start with 0 deposits");
-        round = 1;
+
         firstRoundStartTime = block.timestamp;
+        round = 1;
+
+        address roundPool = _getOrCreateRoundPool(1);
+        SportAMMLiquidityPoolRound(roundPool).updateRoundTimes(firstRoundStartTime, getRoundEndTime(1));
+
         started = true;
         emit PoolStarted();
     }
@@ -125,6 +138,7 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
 
         if (!whitelistedDeposits[msg.sender]) {
             require(!onlyWhitelistedStakersAllowed || whitelistedStakers[msg.sender], "Only whitelisted stakers allowed");
+            require(address(stakingThales) != address(0), "Staking Thales not set");
             require(
                 (balancesPerRound[round][msg.sender] + amount + balancesPerRound[nextRound][msg.sender]) <=
                     _transformCollateral((stakingThales.stakedBalanceOf(msg.sender) * stakedThalesMultiplier) / ONE),
@@ -177,7 +191,7 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
             sUSD.safeTransferFrom(liquidityPoolRound, address(sportsAMM), amountToMint);
         } else {
             uint poolBalance = sUSD.balanceOf(liquidityPoolRound);
-            if (poolBalance > amountToMint) {
+            if (poolBalance >= amountToMint) {
                 sUSD.safeTransferFrom(liquidityPoolRound, address(sportsAMM), amountToMint);
             } else {
                 uint differenceToLPAsDefault = amountToMint - poolBalance;
@@ -244,8 +258,8 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
         }
     }
 
-    /// @notice request withdrawal from the LP
-    /// @param market to check
+    /// @notice Create a round pool by market maturity date if it doesnt already exist
+    /// @param market to use
     /// @return roundPool the pool for the passed market
     function getOrCreateMarketPool(address market)
         external
@@ -267,6 +281,7 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
         require(balancesPerRound[round + 1][msg.sender] == 0, "Can't withdraw as you already deposited for next round");
 
         if (!whitelistedDeposits[msg.sender]) {
+            require(address(stakingThales) != address(0), "Staking Thales not set");
             require(
                 balancesPerRound[round][msg.sender] <
                     _transformCollateral(((stakingThales.stakedBalanceOf(msg.sender) * stakedThalesMultiplier) / ONE)),
@@ -305,6 +320,8 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
         }
 
         roundClosingPrepared = true;
+
+        emit RoundClosingPrepared(round);
     }
 
     /// @notice Prepare round closing
@@ -338,6 +355,8 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
             }
             usersProcessedInRound = usersProcessedInRound + 1;
         }
+
+        emit RoundClosingBatchProcessed(round, batchSize);
     }
 
     /// @notice Close current round and begin next round,
@@ -564,7 +583,7 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
         if (roundPool == address(0)) {
             require(poolRoundMastercopy != address(0), "Round pool mastercopy not set");
             SportAMMLiquidityPoolRound newRoundPool = SportAMMLiquidityPoolRound(Clones.clone(poolRoundMastercopy));
-            newRoundPool.initialize(address(this), sUSD, _round, getRoundEndTime(_round), getRoundEndTime(_round + 1));
+            newRoundPool.initialize(address(this), sUSD, _round, getRoundEndTime(_round - 1), getRoundEndTime(_round));
             roundPool = address(newRoundPool);
             roundPools[_round] = roundPool;
             emit RoundPoolCreated(_round, roundPool);
@@ -581,17 +600,13 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
     /// @param flagToSet self explanatory
     function setOnlyWhitelistedStakersAllowed(bool flagToSet) external onlyOwner {
         onlyWhitelistedStakersAllowed = flagToSet;
-    }
-
-    /// @notice setNeedsTransformingCollateral sets needsTransformingCollateral value
-    /// @param _needsTransformingCollateral boolen value to be set
-    function setNeedsTransformingCollateral(bool _needsTransformingCollateral) external onlyOwner {
-        needsTransformingCollateral = _needsTransformingCollateral;
+        emit SetOnlyWhitelistedStakersAllowed(flagToSet);
     }
 
     /// @notice Set _poolRoundMastercopy
     /// @param _poolRoundMastercopy to clone round pools from
     function setPoolRoundMastercopy(address _poolRoundMastercopy) external onlyOwner {
+        require(_poolRoundMastercopy != address(0), "Can not set a zero address!");
         poolRoundMastercopy = _poolRoundMastercopy;
         emit PoolRoundMastercopyChanged(poolRoundMastercopy);
     }
@@ -606,6 +621,7 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
     /// @notice Set IStakingThales contract
     /// @param _stakingThales IStakingThales address
     function setStakingThales(IStakingThales _stakingThales) external onlyOwner {
+        require(address(_stakingThales) != address(0), "Can not set a zero address!");
         stakingThales = _stakingThales;
         emit StakingThalesChanged(address(_stakingThales));
     }
@@ -634,6 +650,7 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
     /// @notice Set ThalesAMM contract
     /// @param _sportAMM ThalesAMM address
     function setSportAmm(ISportsAMM _sportAMM) external onlyOwner {
+        require(address(_sportAMM) != address(0), "Can not set a zero address!");
         sportsAMM = _sportAMM;
         sUSD.approve(address(sportsAMM), type(uint256).max);
         emit SportAMMChanged(address(_sportAMM));
@@ -642,6 +659,7 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
     /// @notice Set defaultLiquidityProvider wallet
     /// @param _defaultLiquidityProvider default liquidity provider
     function setDefaultLiquidityProvider(address _defaultLiquidityProvider) external onlyOwner {
+        require(_defaultLiquidityProvider != address(0), "Can not set a zero address!");
         defaultLiquidityProvider = _defaultLiquidityProvider;
         emit DefaultLiquidityProviderChanged(_defaultLiquidityProvider);
     }
@@ -652,57 +670,6 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
         require(!started, "Can't change round length after start");
         roundLength = _roundLength;
         emit RoundLengthChanged(_roundLength);
-    }
-
-    /// @notice This method only serves as a failsafe to extract tokens from a pool round contract
-    /// @param tokens to iterate and transfer
-    /// @param account Address where to send the tokens
-    /// @param amount Amount of tokens to be sent
-    /// @param pool where to transfer from
-    /// @param all ignore amount and send whole balance
-    function transferTokensFromLiquidityPool(
-        address[] calldata tokens,
-        address payable account,
-        uint amount,
-        bool all,
-        address pool
-    ) external onlyOwner {
-        require(tokens.length > 0, "tokens array cant be empty");
-        for (uint256 index = 0; index < tokens.length; index++) {
-            if (all) {
-                IERC20Upgradeable(tokens[index]).safeTransferFrom(
-                    pool,
-                    account,
-                    IERC20Upgradeable(tokens[index]).balanceOf(pool)
-                );
-            } else {
-                IERC20Upgradeable(tokens[index]).safeTransferFrom(pool, account, amount);
-            }
-        }
-    }
-
-    /// @notice This method only serves as a failsafe to extract tokens from this contract
-    /// @param tokens to iterate and transfer
-    /// @param account Address where to send the tokens
-    /// @param amount Amount of tokens to be sent
-    /// @param all ignore amount and send whole balance
-    function transferTokens(
-        address[] calldata tokens,
-        address payable account,
-        uint amount,
-        bool all
-    ) external onlyOwner {
-        require(tokens.length > 0, "Whitelisted addresses cannot be empty");
-        for (uint256 index = 0; index < tokens.length; index++) {
-            if (all) {
-                IERC20Upgradeable(tokens[index]).safeTransfer(
-                    account,
-                    IERC20Upgradeable(tokens[index]).balanceOf(address(this))
-                );
-            } else {
-                IERC20Upgradeable(tokens[index]).safeTransfer(account, amount);
-            }
-        }
     }
 
     /// @notice set addresses which can deposit into the AMM bypassing the staking checks
@@ -770,4 +737,7 @@ contract SportAMMLiquidityPool is Initializable, ProxyOwned, PausableUpgradeable
     event AddedIntoWhitelist(address _whitelistAddress, bool _flag);
     event AddedIntoWhitelistStaker(address _whitelistAddress, bool _flag);
     event RoundLengthChanged(uint roundLength);
+    event SetOnlyWhitelistedStakersAllowed(bool flagToSet);
+    event RoundClosingPrepared(uint round);
+    event RoundClosingBatchProcessed(uint round, uint batchSize);
 }

--- a/contracts/SportMarkets/LiquidityPool/SportAMMLiquidityPoolRound.sol
+++ b/contracts/SportMarkets/LiquidityPool/SportAMMLiquidityPoolRound.sol
@@ -22,7 +22,7 @@ contract SportAMMLiquidityPoolRound {
 
     /* ========== CONSTRUCTOR ========== */
 
-    bool public initialized = false;
+    bool public initialized;
 
     function initialize(
         address _liquidityPool,
@@ -39,6 +39,12 @@ contract SportAMMLiquidityPoolRound {
         roundStartTime = _roundStartTime;
         roundEndTime = _roundEndTime;
         sUSD.approve(_liquidityPool, type(uint256).max);
+    }
+
+    function updateRoundTimes(uint _roundStartTime, uint _roundEndTime) external onlyLiquidityPool {
+        roundStartTime = _roundStartTime;
+        roundEndTime = _roundEndTime;
+        emit RoundTimesUpdated(_roundStartTime, _roundEndTime);
     }
 
     function exerciseMarketReadyToExercised(ISportPositionalMarket market) external onlyLiquidityPool {
@@ -62,4 +68,6 @@ contract SportAMMLiquidityPoolRound {
         require(msg.sender == address(liquidityPool), "only the Pool manager may perform these methods");
         _;
     }
+
+    event RoundTimesUpdated(uint _roundStartTime, uint _roundEndTime);
 }

--- a/scripts/abi/ERC721.json
+++ b/scripts/abi/ERC721.json
@@ -244,7 +244,7 @@
       },
       {
         "internalType": "bytes",
-        "name": "_data",
+        "name": "data",
         "type": "bytes"
       }
     ],

--- a/scripts/abi/ERC721URIStorage.json
+++ b/scripts/abi/ERC721URIStorage.json
@@ -228,7 +228,7 @@
       },
       {
         "internalType": "bytes",
-        "name": "_data",
+        "name": "data",
         "type": "bytes"
       }
     ],

--- a/scripts/abi/IERC20Metadata.json
+++ b/scripts/abi/IERC20Metadata.json
@@ -172,7 +172,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "recipient",
+        "name": "to",
         "type": "address"
       },
       {
@@ -196,12 +196,12 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "sender",
+        "name": "from",
         "type": "address"
       },
       {
         "internalType": "address",
-        "name": "recipient",
+        "name": "to",
         "type": "address"
       },
       {

--- a/scripts/abi/MarchMadness.json
+++ b/scripts/abi/MarchMadness.json
@@ -849,7 +849,7 @@
       },
       {
         "internalType": "bytes",
-        "name": "_data",
+        "name": "data",
         "type": "bytes"
       }
     ],

--- a/scripts/abi/OvertimeVoucher.json
+++ b/scripts/abi/OvertimeVoucher.json
@@ -714,7 +714,7 @@
       },
       {
         "internalType": "bytes",
-        "name": "_data",
+        "name": "data",
         "type": "bytes"
       }
     ],

--- a/scripts/abi/OvertimeWorldCupZebro.json
+++ b/scripts/abi/OvertimeWorldCupZebro.json
@@ -701,7 +701,7 @@
       },
       {
         "internalType": "bytes",
-        "name": "_data",
+        "name": "data",
         "type": "bytes"
       }
     ],

--- a/scripts/abi/SportAMMLiquidityPool.json
+++ b/scripts/abi/SportAMMLiquidityPool.json
@@ -222,6 +222,38 @@
       {
         "indexed": false,
         "internalType": "uint256",
+        "name": "round",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "batchSize",
+        "type": "uint256"
+      }
+    ],
+    "name": "RoundClosingBatchProcessed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "round",
+        "type": "uint256"
+      }
+    ],
+    "name": "RoundClosingPrepared",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "roundLength",
         "type": "uint256"
       }
@@ -246,6 +278,19 @@
       }
     ],
     "name": "RoundPoolCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "flagToSet",
+        "type": "bool"
+      }
+    ],
+    "name": "SetOnlyWhitelistedStakersAllowed",
     "type": "event"
   },
   {
@@ -750,6 +795,11 @@
             "internalType": "uint256",
             "name": "_maxAllowedUsers",
             "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "_needsTransformingCollateral",
+            "type": "bool"
           }
         ],
         "internalType": "struct SportAMMLiquidityPool.InitParams",
@@ -1125,19 +1175,6 @@
     "inputs": [
       {
         "internalType": "bool",
-        "name": "_needsTransformingCollateral",
-        "type": "bool"
-      }
-    ],
-    "name": "setNeedsTransformingCollateral",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bool",
         "name": "flagToSet",
         "type": "bool"
       }
@@ -1379,67 +1416,6 @@
       }
     ],
     "name": "transferOwnershipAtInit",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address[]",
-        "name": "tokens",
-        "type": "address[]"
-      },
-      {
-        "internalType": "address payable",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "all",
-        "type": "bool"
-      }
-    ],
-    "name": "transferTokens",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address[]",
-        "name": "tokens",
-        "type": "address[]"
-      },
-      {
-        "internalType": "address payable",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "all",
-        "type": "bool"
-      },
-      {
-        "internalType": "address",
-        "name": "pool",
-        "type": "address"
-      }
-    ],
-    "name": "transferTokensFromLiquidityPool",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/scripts/abi/SportAMMLiquidityPoolRound.json
+++ b/scripts/abi/SportAMMLiquidityPoolRound.json
@@ -1,5 +1,24 @@
 [
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_roundStartTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_roundEndTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "RoundTimesUpdated",
+    "type": "event"
+  },
+  {
     "inputs": [
       {
         "internalType": "contract ISportPositionalMarket",
@@ -144,6 +163,24 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_roundStartTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_roundEndTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateRoundTimes",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   }
 ]

--- a/scripts/abi/SportAMMLiquidityPoolRoundMastercopy.json
+++ b/scripts/abi/SportAMMLiquidityPoolRoundMastercopy.json
@@ -5,6 +5,25 @@
     "type": "constructor"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_roundStartTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_roundEndTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "RoundTimesUpdated",
+    "type": "event"
+  },
+  {
     "inputs": [
       {
         "internalType": "contract ISportPositionalMarket",
@@ -149,6 +168,24 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_roundStartTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_roundEndTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateRoundTimes",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   }
 ]

--- a/test/contracts/SportMarkets/ParlayAMM.js
+++ b/test/contracts/SportMarkets/ParlayAMM.js
@@ -565,6 +565,7 @@ contract('ParlayAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(100000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/ParlayAMMSingledOut.js
+++ b/test/contracts/SportMarkets/ParlayAMMSingledOut.js
@@ -565,6 +565,7 @@ contract('ParlayAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(100000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/ParlayAMM_Arbi.js
+++ b/test/contracts/SportMarkets/ParlayAMM_Arbi.js
@@ -566,6 +566,7 @@ contract('ParlayAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(100000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/SportsAMM.js
+++ b/test/contracts/SportMarkets/SportsAMM.js
@@ -449,6 +449,7 @@ contract('SportsAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(1000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/SportsAMMDiscounts.js
+++ b/test/contracts/SportMarkets/SportsAMMDiscounts.js
@@ -438,6 +438,7 @@ contract('SportsAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(1000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/SportsAMMDiscounts2.js
+++ b/test/contracts/SportMarkets/SportsAMMDiscounts2.js
@@ -439,6 +439,7 @@ contract('SportsAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(1000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/SportsAMMDiscounts3.js
+++ b/test/contracts/SportMarkets/SportsAMMDiscounts3.js
@@ -439,6 +439,7 @@ contract('SportsAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(1000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/SportsAMMDoubleChance.js
+++ b/test/contracts/SportMarkets/SportsAMMDoubleChance.js
@@ -450,6 +450,7 @@ contract('SportsAMM DoubleChance', (accounts) => {
 				_maxAllowedDeposit: toUnit(10000000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/SportsAMMLPing.js
+++ b/test/contracts/SportMarkets/SportsAMMLPing.js
@@ -443,6 +443,7 @@ contract('SportsAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(1000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/SportsAMMLPingTransformCollateral.js
+++ b/test/contracts/SportMarkets/SportsAMMLPingTransformCollateral.js
@@ -450,6 +450,7 @@ contract('SportsAMM', (accounts) => {
 				_maxAllowedDeposit: toUnitSix(1000).toString(),
 				_minDepositAmount: toUnitSix(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: true,
 			},
 			{ from: owner }
 		);
@@ -470,10 +471,6 @@ contract('SportsAMM', (accounts) => {
 		await testUSDC.mint(curveSUSD.address, toUnit(100000));
 		await testUSDC.approve(SportsAMM.address, toUnit(100000), { from: first });
 		await SportsAMM.setCapPerSport(tagID_4, toUnit('50000'), { from: owner });
-
-		await SportAMMLiquidityPool.setNeedsTransformingCollateral(true, {
-			from: owner,
-		});
 	});
 
 	describe('Test SportsAMM LPing', () => {

--- a/test/contracts/SportMarkets/SportsAMMSingleBuy.js
+++ b/test/contracts/SportMarkets/SportsAMMSingleBuy.js
@@ -449,6 +449,7 @@ contract('SportsAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(1000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/SportsAMMSpreadCheck.js
+++ b/test/contracts/SportMarkets/SportsAMMSpreadCheck.js
@@ -438,6 +438,7 @@ contract('SportsAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(1000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/SportsAMMSpreadTwoOptions.js
+++ b/test/contracts/SportMarkets/SportsAMMSpreadTwoOptions.js
@@ -437,6 +437,7 @@ contract('SportsAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(1000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/SportsVoucher.js
+++ b/test/contracts/SportMarkets/SportsVoucher.js
@@ -405,6 +405,7 @@ contract('SportsVauchers', (accounts) => {
 				_maxAllowedDeposit: toUnit(1000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportMarkets/SportsVoucherWithTransformCollateral.js
+++ b/test/contracts/SportMarkets/SportsVoucherWithTransformCollateral.js
@@ -410,6 +410,7 @@ contract('SportsVauchers', (accounts) => {
 				_maxAllowedDeposit: toUnit(1000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportVaults/ParlayVault.js
+++ b/test/contracts/SportVaults/ParlayVault.js
@@ -735,6 +735,7 @@ contract('Parlay Vault', (accounts) => {
 				_maxAllowedDeposit: toUnit(100000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);

--- a/test/contracts/SportVaults/SportVault.js
+++ b/test/contracts/SportVaults/SportVault.js
@@ -441,6 +441,7 @@ contract('SportsAMM', (accounts) => {
 				_maxAllowedDeposit: toUnit(1000).toString(),
 				_minDepositAmount: toUnit(100).toString(),
 				_maxAllowedUsers: 100,
+				_needsTransformingCollateral: false,
 			},
 			{ from: owner }
 		);


### PR DESCRIPTION
4.1 Method to set the variable was removed and the variable was added to the initializer logic.
4.2 Admin transfer methods were added as a failsafe in case ownersip of the proxy is lost by mistake or that an urgent action needs be taken to prevent further damage in case an exploit is suspected. Those methods are removed now.
4.3 Check have been added.
4.4 We believe that this finding is incorrect. The round times are statically defined as soon as firstRoundStartTime is set, and trading in a futuristic round can take place before that round has begun. Closing the round does not have a relation to RoundEndTime, although a different naming of variables and methods could alleviate this semantic missunderstanding.
4.5. Fixed by adding the method to update roundTimes and using in in `start` method
4.6. All events have been added
4.7. The suggested constructor has been added, but there is a compiler error, so commented out for now
4.8. Fixed
4.9. Noted, but won't fix immediately as these gas savings are non-material on Optimistic Rollups
4.10. Noted, but won't fix immediately as these gas savings are non-material on Optimistic Rollups
4.11 Noted, but won't fix immediately as these gas savings are non-material on Optimistic Rollups
4.12. Comment was fixed
4.13. The method was removed alltogether in 4.2.
4.14. Fixed per suggestion
4.15. Fixed per suggestion