### PR TITLE
Add strike price publish time to Speed market

### DIFF
--- a/contracts/SpeedMarkets/SpeedMarket.sol
+++ b/contracts/SpeedMarkets/SpeedMarket.sol
@@ -15,6 +15,7 @@ contract SpeedMarket {
         bytes32 _asset;
         uint64 _strikeTime;
         int64 _strikePrice;
+        uint64 _strikePricePublishTime;
         Direction _direction;
         uint _buyinAmount;
         uint _safeBoxImpact;
@@ -30,6 +31,7 @@ contract SpeedMarket {
     bytes32 public asset;
     uint64 public strikeTime;
     int64 public strikePrice;
+    uint64 public strikePricePublishTime;
     Direction public direction;
     uint public buyinAmount;
 
@@ -56,6 +58,7 @@ contract SpeedMarket {
         asset = params._asset;
         strikeTime = params._strikeTime;
         strikePrice = params._strikePrice;
+        strikePricePublishTime = params._strikePricePublishTime;
         direction = params._direction;
         buyinAmount = params._buyinAmount;
         safeBoxImpact = params._safeBoxImpact;

--- a/contracts/SpeedMarkets/SpeedMarkets.sol
+++ b/contracts/SpeedMarkets/SpeedMarkets.sol
@@ -693,6 +693,7 @@ contract SpeedMarkets is Initializable, ProxyOwned, ProxyPausable, ProxyReentran
         uint _maxRiskPerAssetAndDirection
     ) external onlyOwner {
         maxRiskPerAsset[asset] = _maxRiskPerAsset;
+        currentRiskPerAsset[asset] = 0;
         maxRiskPerAssetAndDirection[asset][Direction.Up] = _maxRiskPerAssetAndDirection;
         maxRiskPerAssetAndDirection[asset][Direction.Down] = _maxRiskPerAssetAndDirection;
         emit SetMaxRisks(asset, _maxRiskPerAsset, _maxRiskPerAssetAndDirection);

--- a/contracts/SpeedMarkets/SpeedMarkets.sol
+++ b/contracts/SpeedMarkets/SpeedMarkets.sol
@@ -37,6 +37,7 @@ contract SpeedMarkets is Initializable, ProxyOwned, ProxyPausable, ProxyReentran
         bytes32 asset;
         uint64 strikeTime;
         int64 strikePrice;
+        uint64 strikePricePublishTime;
         int64 finalPrice;
         Direction direction;
         Direction result;
@@ -349,6 +350,7 @@ contract SpeedMarkets is Initializable, ProxyOwned, ProxyPausable, ProxyReentran
             asset,
             strikeTime,
             tempData.pythPrice.price,
+            uint64(tempData.pythPrice.publishTime),
             0,
             direction,
             direction,

--- a/contracts/SpeedMarkets/SpeedMarketsAMM.sol
+++ b/contracts/SpeedMarkets/SpeedMarketsAMM.sol
@@ -346,6 +346,7 @@ contract SpeedMarketsAMM is Initializable, ProxyOwned, ProxyPausable, ProxyReent
                 asset,
                 strikeTime,
                 tempData.pythPrice.price,
+                uint64(tempData.pythPrice.publishTime),
                 direction,
                 buyinAmount,
                 safeBoxImpact,

--- a/contracts/SpeedMarkets/SpeedMarketsAMM.sol
+++ b/contracts/SpeedMarkets/SpeedMarketsAMM.sol
@@ -638,7 +638,7 @@ contract SpeedMarketsAMM is Initializable, ProxyOwned, ProxyPausable, ProxyReent
         uint _maxRiskPerAssetAndDirection
     ) external onlyOwner {
         maxRiskPerAsset[asset] = _maxRiskPerAsset;
-        currentRiskPerAsset[asset] = 0; // TODO: this can be removed with next upgrade
+        currentRiskPerAsset[asset] = 0;
         maxRiskPerAssetAndDirection[asset][SpeedMarket.Direction.Up] = _maxRiskPerAssetAndDirection;
         maxRiskPerAssetAndDirection[asset][SpeedMarket.Direction.Down] = _maxRiskPerAssetAndDirection;
         emit SetMaxRisks(asset, _maxRiskPerAsset, _maxRiskPerAssetAndDirection);

--- a/contracts/interfaces/ISpeedMarkets.sol
+++ b/contracts/interfaces/ISpeedMarkets.sol
@@ -15,6 +15,7 @@ interface ISpeedMarkets {
         bytes32 asset;
         uint64 strikeTime;
         int64 strikePrice;
+        uint64 strikePricePublishTime;
         int64 finalPrice;
         Direction direction;
         Direction result;

--- a/scripts/abi/ISpeedMarkets.json
+++ b/scripts/abi/ISpeedMarkets.json
@@ -384,6 +384,11 @@
             "type": "int64"
           },
           {
+            "internalType": "uint64",
+            "name": "strikePricePublishTime",
+            "type": "uint64"
+          },
+          {
             "internalType": "int64",
             "name": "finalPrice",
             "type": "int64"

--- a/scripts/abi/SpeedMarket.json
+++ b/scripts/abi/SpeedMarket.json
@@ -119,6 +119,11 @@
             "type": "int64"
           },
           {
+            "internalType": "uint64",
+            "name": "_strikePricePublishTime",
+            "type": "uint64"
+          },
+          {
             "internalType": "enum SpeedMarket.Direction",
             "name": "_direction",
             "type": "uint8"
@@ -261,6 +266,19 @@
         "internalType": "int64",
         "name": "",
         "type": "int64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "strikePricePublishTime",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
       }
     ],
     "stateMutability": "view",

--- a/scripts/abi/SpeedMarketMastercopy.json
+++ b/scripts/abi/SpeedMarketMastercopy.json
@@ -124,6 +124,11 @@
             "type": "int64"
           },
           {
+            "internalType": "uint64",
+            "name": "_strikePricePublishTime",
+            "type": "uint64"
+          },
+          {
             "internalType": "enum SpeedMarket.Direction",
             "name": "_direction",
             "type": "uint8"
@@ -266,6 +271,19 @@
         "internalType": "int64",
         "name": "",
         "type": "int64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "strikePricePublishTime",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
       }
     ],
     "stateMutability": "view",

--- a/scripts/abi/SpeedMarkets.json
+++ b/scripts/abi/SpeedMarkets.json
@@ -1438,6 +1438,11 @@
         "type": "int64"
       },
       {
+        "internalType": "uint64",
+        "name": "strikePricePublishTime",
+        "type": "uint64"
+      },
+      {
         "internalType": "int64",
         "name": "finalPrice",
         "type": "int64"

--- a/test/contracts/SpeedMarkets/SpeedMarkets.js
+++ b/test/contracts/SpeedMarkets/SpeedMarkets.js
@@ -189,7 +189,9 @@ contract('SpeedMarkets', (accounts) => {
 			let SpeedMarket = artifacts.require('SpeedMarket');
 			let speedMarket = await SpeedMarket.at(market);
 			let strikeTime = await speedMarket.strikeTime();
+			const publishTime = await speedMarket.strikePricePublishTime();
 			console.log('Strike time is ' + strikeTime);
+			console.log('Publish time is ' + publishTime);
 
 			let marketData = await speedMarketsAMMData.getMarketsData([market]);
 			console.log('marketData ' + marketData);

--- a/test/contracts/SpeedMarkets/ZKSync_SpeedMarkets.js
+++ b/test/contracts/SpeedMarkets/ZKSync_SpeedMarkets.js
@@ -204,11 +204,10 @@ contract('SpeedMarkets', (accounts) => {
 			let marketPerUser = marketsPerUser[0];
 			console.log('marketPerUser is ' + marketPerUser);
 
-			// let SpeedMarket = artifacts.require('SpeedMarket');
-			// let speedMarket = await SpeedMarket.at(market);
 			let speedMarket = await speedMarketsAMM.speedMarket(market);
 			let strikeTime = speedMarket.strikeTime;
 			console.log('Strike time is ' + speedMarket.strikeTime);
+			console.log('Publish time is ' + speedMarket.strikePricePublishTime);
 
 			let marketData = await speedMarketsAMMData.getMarketsData([market]);
 			console.log('marketData ' + marketData);

--- a/test/contracts/SpeedMarkets/ZKSync_SpeedMarkets2.js
+++ b/test/contracts/SpeedMarkets/ZKSync_SpeedMarkets2.js
@@ -166,6 +166,7 @@ contract('SpeedMarkets', (accounts) => {
 			let speedMarket = await speedMarketsAMM.speedMarket(market);
 			let strikeTime = speedMarket.strikeTime;
 			console.log('Strike time is ' + speedMarket.strikeTime);
+			console.log('Publish time is ' + speedMarket.strikePricePublishTime);
 
 			let marketData = await speedMarketsAMMData.getMarketsData([
 				markets[0],


### PR DESCRIPTION
- Minor change: Align Speed AMM setter for max risk per asset on zkSync with other networks