### PR TITLE
Staking and CCIP transition to USDC

### DIFF
--- a/contracts/EscrowAndStaking/StakingThales.sol
+++ b/contracts/EscrowAndStaking/StakingThales.sol
@@ -268,6 +268,11 @@ contract StakingThales is IStakingThales, Initializable, ProxyOwned, ProxyReentr
         emit StakingRewardsParametersChanged(_fixedReward, _extraReward, _extraRewardsActive);
     }
 
+    function setFeeToken(address _feeToken) external onlyOwner {
+        require(paused, "Contract must be paused");
+        feeToken = IERC20(_feeToken);
+    }
+
     /// @notice Set contract addresses
     /// @param _thalesAMM address of Thales AMM contract
     /// @param _thalesRangedAMM address of Thales ranged AMM contract

--- a/scripts/abi/StakingThales.json
+++ b/scripts/abi/StakingThales.json
@@ -1460,6 +1460,21 @@
     "constant": false,
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_feeToken",
+        "type": "address"
+      }
+    ],
+    "name": "setFeeToken",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "_lastPeriodTimestamp",
         "type": "uint256"

--- a/test/contracts/Staking/CCIP2_StakingThales.js
+++ b/test/contracts/Staking/CCIP2_StakingThales.js
@@ -1193,6 +1193,9 @@ contract('StakingThales', (accounts) => {
 			await fastForward(WEEK + SECOND);
 			await StakingThalesDeployed.closePeriod({ from: second });
 			answer = await StakingThalesDeployed.getRewardsAvailable(first);
+			// Check if feeToken is equal to sUSDSynth address
+			const feeToken = await StakingThalesDeployed.feeToken();
+			assert.equal(feeToken, sUSDSynth.address);
 			await StakingThalesDeployed.claimReward({ from: first });
 
 			// Pause the StakingThales contract


### PR DESCRIPTION
Transition from sUSD/USDbC -> USDC
Steps:
1. Upgrade Staking contract (add `setFeeToken(address newFeeToken)` function)
2. Pause StakingThales
4. Set new feeToken (USDC) using `setFeeToken(USDC_address)` on **StakingThales**
5. Set new feeToken (USDC) using `setSUSD(USDC_address)`on **SafeBoxBuffer**
6. Withdraw old feeToken (sUSD/USDCb) from StakingThales
7. (Swap &) Send equal amount of new collateral to StakingThales
8. Send funds of new collateral to SafeBoxBuffer
9. Batch transactions:
    - unpause StakingThales
    - closePeriod() on StakingThales
